### PR TITLE
Update wscript to support waf 1.6.X

### DIFF
--- a/ns3/blackadder-model/wscript
+++ b/ns3/blackadder-model/wscript
@@ -1,7 +1,7 @@
 ## -*- Mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8; -*-
 
 import os
-import Options
+from waflib import Options
 
 
 def options(opt):
@@ -114,7 +114,7 @@ def build(bld):
         module.use.extend(['NSCLICK', 'DL'])
         module_test.use.extend(['NSCLICK', 'DL'])
 
-    headers = bld.new_task_gen(features=['ns3header'])
+    headers = bld(features='ns3header')
     headers.module = 'blackadder'
     headers.source = [
         'model/click-bridge.h',
@@ -127,6 +127,6 @@ def build(bld):
         ]
 
     if (bld.env['ENABLE_EXAMPLES']):
-        bld.add_subdirs('examples')
+        bld.recurse('examples')
 
     #bld.ns3_python_bindings()


### PR DESCRIPTION
- Method 'add_subdirs' was replaced by method 'recurse' (see [1])
- Method 'new_task_gen' disappears (see [2])

[1] http://docs.waf.googlecode.com/git/book_16/intro_waf_1.6.pdf (Section 1.3)
[2] http://docs.waf.googlecode.com/git/book_16/intro_waf_1.6.pdf (Section 1.5)
