### PR TITLE
Fix TM topology reading (ns-3 version) in optimized builds

### DIFF
--- a/ns3/blackadder-model/model/topology-manager.cc
+++ b/ns3/blackadder-model/model/topology-manager.cc
@@ -53,7 +53,8 @@ namespace ns3 {
         PubSubApplication::StartApplication();
         /*read the graphML file that describes the topology*/
         NS_LOG_INFO("FILENAME: " << m_filename);
-        NS_ASSERT_MSG(m_tm_igraph.readTopology(m_filename.c_str()) >= 0, "TM: couldn't read topology file...aborting");
+        int res = m_tm_igraph.readTopology(m_filename.c_str());
+        NS_ASSERT_MSG(res >= 0, "TM: couldn't read topology file...aborting");
         NS_LOG_INFO("Blackadder Node: " << m_tm_igraph.nodeID);
         /***************************************************/
         /*I should write a read hander that reads the Node Identifier (and other useful information)*/


### PR DESCRIPTION
In optimized builds, NS_ASSERT_MSG is removed and, therefore, the instruction 'm_tm_igraph.readTopology(m_filename.c_str())' is never executed.

(see https://www.nsnam.org/doxygen/group__assert.html)
